### PR TITLE
Update data-comp-anchor.md

### DIFF
--- a/source/attributes/data-comp-anchor.md
+++ b/source/attributes/data-comp-anchor.md
@@ -10,17 +10,9 @@ Anchoring is achieved using the anchoring component, `data-comp-anchor`, it has 
 
 There are currently three types of anchors:
 
-## `fixed`
-
-Positions the anchored element directly in front of the user whenever an XR session is started.
-
-## `floating`
-
-Allows the user to place the anchored element where they choose, using a look/pinch gesture. The user can place it floating in their space or on the scene mesh.
-
-## `plane`
-
-Anchors the element to the nearest plane that matches the specified label or orientation.
+- `fixed`: Positions the anchored element directly in front of the user whenever an XR session is started.
+- `floating`: Allows the user to place the anchored element where they choose, using a look/pinch gesture. The user can place it floating in their space or on the scene mesh.
+- `plane`: Anchors the element to the nearest plane that matches the specified label or orientation.
 
 If no label or orientation is specified, the element will be anchored to the nearest plane.
 


### PR DESCRIPTION
put the values of `type` as a child list instead of what seemingly can look like sibling sections